### PR TITLE
chore(Client): remove refering to client.GCommandsClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Packages
+node_modules/
+package-lock.json

--- a/src/base/GEventLoader.js
+++ b/src/base/GEventLoader.js
@@ -38,7 +38,7 @@ class GEventLoader {
             file._path = `${this.eventDir}/${fileName}${fileType}`;
 
             this.client.gevents.set(fileName, file);
-            this.Gclient.emit(Events.LOG, new Color('&d[GEvents] &aLoaded (File): &e➜   &3' + fileName, {json:false}).getText());
+            this.client.emit(Events.LOG, new Color('&d[GEvents] &aLoaded (File): &e➜   &3' + fileName, {json:false}).getText());
         }
 
         await this.__loadEvents()

--- a/src/base/GEventLoader.js
+++ b/src/base/GEventLoader.js
@@ -5,16 +5,12 @@ const Event = require('../structures/Event');
 const { isClass } = require('../util/util');
 
 class GEventLoader {
-    constructor(GCommandsClient, options = {}) {
-        if(!GCommandsClient.client) { 
-            GCommandsClient = { client: GCommandsClient }
-            GCommandsClient.emit = (event, data) => console.log(data)
-        }
-        if (typeof GCommandsClient.client !== 'object') return console.log(new Color('&d[GEvents] &cNo discord.js client provided!',{json:false}).getText());
+    constructor(client, options = {}) {
+        if (typeof client !== 'object') return console.log(new Color('&d[GEvents] &cNo discord.js client provided!',{json:false}).getText());
 
-        this.GCommandsClient = GCommandsClient;
-        this.eventDir = this.GCommandsClient.eventDir ? this.GCommandsClient.eventDir : options.eventDir;
-        this.client = GCommandsClient.client;
+        this.client = client;
+
+        this.eventDir = this.client.eventDir ? this.client.eventDir : options.eventDir;
         this.client.gevents = new Collection();
 
         if(!this.eventDir) return;
@@ -38,10 +34,10 @@ class GEventLoader {
 
                     finalFile._path = `${this.eventDir}/${fileName}.${fileType}`;
                     this.client.gevents.set(finalFile.name, finalFile);
-                    this.GCommandsClient.emit(Events.LOG, new Color('&d[GEvents] &aLoaded (File): &e➜   &3' + fileName, {json:false}).getText());
+                    this.client.emit(Events.LOG, new Color('&d[GEvents] &aLoaded (File): &e➜   &3' + fileName, {json:false}).getText());
                 } catch(e) {
-                    this.GCommandsClient.emit(Events.DEBUG, new Color('&d[GEvents Debug] '+e).getText());
-                    this.GCommandsClient.emit(Events.LOG, new Color('&d[GEvents] &cCan\'t load ' + fileName).getText());
+                    this.client.emit(Events.DEBUG, new Color('&d[GEvents Debug] '+e).getText());
+                    this.client.emit(Events.LOG, new Color('&d[GEvents] &cCan\'t load ' + fileName).getText());
                 }
             } else {
                 for(let eventFile of (await fs.readdirSync(`${this.eventDir}/${dir}`))) {
@@ -59,10 +55,10 @@ class GEventLoader {
 
                         finalFile2._path = `${this.eventDir}/${dir}/${fileName2}.${fileType2}`;
                         this.client.gevents.set(finalFile2.name, finalFile2);
-                        this.GCommandsClient.emit(Events.LOG, new Color('&d[GEvents] &aLoaded (File): &e➜   &3' + fileName2, {json:false}).getText());
+                        this.client.emit(Events.LOG, new Color('&d[GEvents] &aLoaded (File): &e➜   &3' + fileName2, {json:false}).getText());
                     } catch(e) {
-                        this.GCommandsClient.emit(Events.DEBUG, new Color('&d[GEvents Debug] '+e).getText());
-                        this.GCommandsClient.emit(Events.LOG, new Color('&d[GEvents] &cCan\'t load ' + fileName2).getText());
+                        this.client.emit(Events.DEBUG, new Color('&d[GEvents Debug] '+e).getText());
+                        this.client.emit(Events.LOG, new Color('&d[GEvents] &cCan\'t load ' + fileName2).getText());
                     }
                 }
             }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 module.exports = {
     GEvents: require("./base/GEventLoader"),
-    Event: require("./structures/Event")
+    Event: require("./structures/Event"),
+    EventOptionsBuilder: require("./structures/EventOptionsBuilder"),
 }

--- a/src/structures/EventOptionsBuilder.js
+++ b/src/structures/EventOptionsBuilder.js
@@ -1,0 +1,42 @@
+const { resolveString } = require('../util/util');
+
+class EventOptionsBuilder {
+    
+    constructor(data = {}) {
+        this.setup(data);
+    }
+
+    setup(data) {
+        
+        this.name = 'name' in data ? resolveString(data.name) : null;
+        this.once = 'once' in data ? Boolean(data.value) : null;
+        this.ws = 'ws' in data ? Boolean(data.ws) : null;
+
+        return this.toJSON();
+    }
+
+    setName(name) {
+        this.name = resolveString(name);
+        return this;
+    }
+
+    setOnce(once) {
+        this.once = Boolean(once);
+        return this;
+    }
+
+    setWs(ws) {
+        this.ws = Boolean(ws);
+        return this;
+    }
+
+    toJSON() {
+        return {
+          name: this.name,
+          once: this.once,
+          ws: this.ws,
+        };
+      }
+}
+
+module.exports = EventOptionsBuilder;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -17,6 +17,20 @@ declare module '@gcommands/events' {
         public run(client: Client, ...args): void;
     }
 
+    export class EventOptionsBuilder {
+        constructor(data: EventOptions);
+        private setup(data: EventOptions);
+    
+        public name: String;
+        public once: Boolean;
+        public ws: Boolean;
+    
+        public setName(): EventOptionsBuilder;
+        public setOnce(): EventOptionsBuilder;
+        public setWs(): EventOptionsBuilder;
+        public toJSON(): EventOptionsBuilder;
+      }
+
     interface EventOptions {
         name: string;
         once: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged**:
**WARNING: THIS CHANGE ALSO AFFECTS GCOMMANDS, BOTH PR'S SHOULD BE MERGED AT THE SAME TIME**

Garlic-Team/GCommands#213

Changes:
- This PR removes `client.GCommandsClient` associations. This was done because it was just weird how it was used.

This PR apparently also contains changes from a already merged PR #1, it seems like the changes were never actually merged for some reason.

(I don't know why changes that were merged

**Status and versioning classification**:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)